### PR TITLE
[CI] deploy alpha workflow

### DIFF
--- a/.github/workflows/deploy-alpha.yml
+++ b/.github/workflows/deploy-alpha.yml
@@ -1,7 +1,11 @@
 name: Deploy Alpha
 
 on:
-  push:
+  workflow_run:
+    workflows:
+      - tests-e2e
+    types:
+      - completed
     branches:
       - release/alpha
 
@@ -9,6 +13,8 @@ jobs:
 
   deploy-alpha:
     runs-on: ubuntu-latest
+
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Deploy alpha workflow is now triggered after `tests-e2e` workflow is finished with a `success` state.