### PR TITLE
feat: derive queries from endpoints definition

### DIFF
--- a/packages/@econnessione/shared/src/components/AreasMap.tsx
+++ b/packages/@econnessione/shared/src/components/AreasMap.tsx
@@ -1,6 +1,6 @@
 import { Area } from "@io/http";
 import { Typography } from "@material-ui/core";
-import { areasList } from "@providers/DataProvider";
+import { Queries } from "@providers/DataProvider";
 import { navigate } from "@reach/router";
 import { geoJSONFormat } from "@utils/map.utils";
 import ParentSize from "@vx/responsive/lib/components/ParentSize";
@@ -24,7 +24,7 @@ class AreasMap extends React.PureComponent<AreasMapProps> {
     const { center = [9.18951, 45.46427], zoom = 12 } = this.props;
     return (
       <WithQueries
-        queries={{ areas: areasList }}
+        queries={{ areas: Queries.Area.getList }}
         params={{
           areas: {
             pagination: { page: 1, perPage: 20 },

--- a/packages/@econnessione/shared/src/components/EventsMap.tsx
+++ b/packages/@econnessione/shared/src/components/EventsMap.tsx
@@ -1,6 +1,6 @@
 import { Area, Events } from "@io/http";
 import { GetEventsQueryFilter } from "@io/http/Events/Uncategorized";
-import { eventsList } from "@providers/DataProvider";
+import { Queries } from "@providers/DataProvider";
 import { navigate } from "@reach/router";
 import { geoJSONFormat } from "@utils/map.utils";
 import ParentSize from "@vx/responsive/lib/components/ParentSize";
@@ -30,7 +30,7 @@ export const EventsMap: React.FC<EventsMapProps> = ({
   return (
     <WithQueries
       queries={{
-        events: eventsList,
+        events: Queries.Event.getList,
       }}
       params={{
         events: {

--- a/packages/@econnessione/shared/src/components/Header.tsx
+++ b/packages/@econnessione/shared/src/components/Header.tsx
@@ -172,7 +172,9 @@ const Header: React.FC = () => {
     setOpen(false);
   };
 
-  function handleListKeyDown(event: React.KeyboardEvent): void {
+  function handleListKeyDown(
+    event: React.KeyboardEvent<HTMLUListElement>
+  ): void {
     if (event.key === "Tab") {
       event.preventDefault();
       setOpen(false);

--- a/packages/@econnessione/shared/src/components/Map.tsx
+++ b/packages/@econnessione/shared/src/components/Map.tsx
@@ -87,10 +87,15 @@ const Map: React.FC<MapProps> = ({
     const totalPadding = 20 * 2;
 
     if (size) {
-      map.getView().fit(featureSource.getExtent(), {
-        size: [size[0] - totalPadding, size[1] - totalPadding],
-        maxZoom: 12,
-      });
+      if (!featureSource.isEmpty()) {
+        map.getView().fit(featureSource.getExtent(), {
+          size: [size[0] - totalPadding, size[1] - totalPadding],
+          maxZoom: 12,
+        });
+      } else {
+        map.getView().setZoom(10);
+        map.getView().setCenter([0, 0]);
+      }
     }
 
     if (center) {

--- a/packages/@econnessione/shared/src/components/Map/ProjectsMap.tsx
+++ b/packages/@econnessione/shared/src/components/Map/ProjectsMap.tsx
@@ -1,7 +1,7 @@
 import { ErrorBox } from "@components/Common/ErrorBox";
 import { LazyLoader } from "@components/Common/Loader";
 import Map from "@components/Map";
-import { projectList } from "@providers/DataProvider";
+import { Queries } from "@providers/DataProvider";
 import { geoJSONFormat } from "@utils/map.utils";
 import ParentSize from "@vx/responsive/lib/components/ParentSize";
 import * as QR from "avenger/lib/QueryResult";
@@ -24,7 +24,7 @@ export const ProjectsMap: React.FC<ProjectsMapProps> = ({
   return (
     <WithQueries
       queries={{
-        projects: projectList,
+        projects: Queries.Project.getList,
       }}
       params={{
         projects: {

--- a/packages/@econnessione/shared/src/components/lists/ProjectImageList.tsx
+++ b/packages/@econnessione/shared/src/components/lists/ProjectImageList.tsx
@@ -2,7 +2,7 @@ import { ErrorBox } from "@components/Common/ErrorBox";
 import { Loader } from "@components/Common/Loader";
 import * as io from "@io/http";
 import { GridList, GridListTile } from "@material-ui/core";
-import { projectImageList } from "@providers/DataProvider";
+import { Queries } from "@providers/DataProvider";
 import * as QR from "avenger/lib/QueryResult";
 import { WithQueries } from "avenger/lib/react";
 import * as React from "react";
@@ -36,9 +36,9 @@ export class ProjectImageList extends React.PureComponent<ProjectImageListProps>
   render(): JSX.Element {
     return (
       <WithQueries
-        queries={{ projectImageList }}
+        queries={{ projectImages: Queries.ProjectImage.getList }}
         params={{
-          projectImageList: {
+          projectImages: {
             sort: {
               order: "DESC",
               field: "id",
@@ -53,7 +53,7 @@ export class ProjectImageList extends React.PureComponent<ProjectImageListProps>
         render={QR.fold(
           Loader,
           ErrorBox,
-          ({ projectImageList: { data: items } }) => (
+          ({ projectImages: { data: items } }) => (
             <div>
               <GridList cellHeight={160} cols={3}>
                 {items.map((tile) => (

--- a/packages/@econnessione/shared/src/components/sliders/EventSlider.tsx
+++ b/packages/@econnessione/shared/src/components/sliders/EventSlider.tsx
@@ -4,7 +4,7 @@ import { UncategorizedListItem } from "@components/lists/EventList/Uncategorized
 import { Events } from "@io/http";
 import { GetEventsQueryFilter } from "@io/http/Events/Uncategorized";
 import { Typography } from "@material-ui/core";
-import { eventsList } from "@providers/DataProvider";
+import { Queries } from "@providers/DataProvider";
 import * as QR from "avenger/lib/QueryResult";
 import { WithQueries } from "avenger/lib/react";
 import * as R from "fp-ts/lib/Record";
@@ -18,7 +18,7 @@ export interface EventSliderProps {
 export const EventSlider: React.FC<EventSliderProps> = (props) => {
   return (
     <WithQueries
-      queries={{ events: eventsList }}
+      queries={{ events: Queries.Event.getList }}
       params={{
         events: {
           pagination: { perPage: 20, page: 1 },

--- a/packages/@econnessione/shared/src/endpoints/GroupMember.endpoints.ts
+++ b/packages/@econnessione/shared/src/endpoints/GroupMember.endpoints.ts
@@ -5,6 +5,7 @@ import { nonEmptyRecordFromType } from "../io/Common/NonEmptyRecord";
 import * as http from "../io/http";
 import { ListOutput, Output } from "../io/http/Common/Output";
 import { GetListQuery } from "../io/http/Query";
+import { ResourceEndpoints } from "./types";
 
 const SingleGroupMemberOutput = Output(
   http.GroupMember.GroupMember,
@@ -80,4 +81,12 @@ export const Delete = Endpoint({
     Params: t.type({ id: t.string }),
   },
   Output: SingleGroupMemberOutput,
+});
+
+export const groupMembers = ResourceEndpoints({
+  Create,
+  Get,
+  List,
+  Edit,
+  Delete,
 });

--- a/packages/@econnessione/shared/src/endpoints/ProjectImage.endpoints.ts
+++ b/packages/@econnessione/shared/src/endpoints/ProjectImage.endpoints.ts
@@ -1,12 +1,23 @@
+import * as t from "io-ts";
 import { Endpoint } from "ts-endpoint";
 import * as http from "../io/http";
 import { ListOutput } from "../io/http/Common/Output";
 import { GetListQuery } from "../io/http/Query";
+import { ResourceEndpoints } from "./types";
 
 const ListProjectImageOutput = ListOutput(
   http.ProjectImage.ProjectImage,
   "ListProjectImage"
 );
+
+export const Create = Endpoint({
+  Method: "POST",
+  getPath: () => `/project/images`,
+  Input: {
+    Body: t.strict({}),
+  },
+  Output: ListProjectImageOutput,
+});
 
 export const List = Endpoint({
   Method: "GET",
@@ -15,4 +26,32 @@ export const List = Endpoint({
     Query: GetListQuery,
   },
   Output: ListProjectImageOutput,
+});
+
+export const Get = Endpoint({
+  Method: "GET",
+  getPath: ({ id }) => `/project/images/${id}`,
+  Input: {
+    Params: t.type({ id: t.string }),
+  },
+  Output: ListProjectImageOutput,
+});
+
+export const projectImages = ResourceEndpoints({
+  Create,
+  List,
+  Get,
+  Edit: Endpoint({
+    Method: "PUT",
+    getPath: () => `/articles`,
+    Input: {
+      Body: t.unknown,
+    },
+    Output: t.undefined,
+  }),
+  Delete: Endpoint({
+    Method: "DELETE",
+    getPath: () => `/articles`,
+    Output: t.undefined,
+  }),
 });

--- a/packages/@econnessione/shared/src/endpoints/User.endpoints.ts
+++ b/packages/@econnessione/shared/src/endpoints/User.endpoints.ts
@@ -2,6 +2,7 @@ import * as t from "io-ts";
 import { Endpoint } from "ts-endpoint";
 import { GetListQuery } from "../io/http/Query";
 import { User } from "../io/http/User";
+import { ResourceEndpoints } from "./types";
 
 export const UserLogin = Endpoint({
   Method: "POST",
@@ -32,6 +33,16 @@ export const UserCreate = Endpoint({
   }),
 });
 
+export const UserGet = Endpoint({
+  Method: "GET",
+  getPath: ({ id }) => `/users/${id}`,
+  Input: {
+    Query: GetListQuery,
+    Params: t.type({ id: t.string }),
+  },
+  Output: t.strict({ data: t.array(User), total: t.number }),
+});
+
 export const UserList = Endpoint({
   Method: "GET",
   getPath: () => "/users",
@@ -39,4 +50,23 @@ export const UserList = Endpoint({
     Query: GetListQuery,
   },
   Output: t.strict({ data: t.array(User), total: t.number }),
+});
+
+export const users = ResourceEndpoints({
+  Get: UserGet,
+  Create: UserCreate,
+  List: UserList,
+  Edit: Endpoint({
+    Method: "PUT",
+    getPath: () => `/users`,
+    Input: {
+      Body: t.unknown,
+    },
+    Output: t.undefined,
+  }),
+  Delete: Endpoint({
+    Method: "DELETE",
+    getPath: () => `/users`,
+    Output: t.undefined,
+  }),
 });

--- a/packages/@econnessione/shared/src/endpoints/actor.endpoints.ts
+++ b/packages/@econnessione/shared/src/endpoints/actor.endpoints.ts
@@ -81,4 +81,4 @@ export const actors = ResourceEndpoints({
   Edit,
   Create,
   Delete,
-} as any);
+});

--- a/packages/@econnessione/shared/src/endpoints/area.endpoints.ts
+++ b/packages/@econnessione/shared/src/endpoints/area.endpoints.ts
@@ -6,11 +6,12 @@ import { Area } from "../io/http";
 import { Polygon } from "../io/http/Common";
 import { ListOutput, Output } from "../io/http/Common/Output";
 import { GetListQuery } from "../io/http/Query";
+import { ResourceEndpoints } from "./types";
 
 const SingleAreaOutput = Output(Area.Area, "Area");
 const ListAreaOutput = ListOutput(Area.Area, "Areas");
 
-export const List = Endpoint({
+const List = Endpoint({
   Method: "GET",
   getPath: () => "/areas",
   Input: {
@@ -19,7 +20,7 @@ export const List = Endpoint({
   Output: ListAreaOutput,
 });
 
-export const Get = Endpoint({
+const Get = Endpoint({
   Method: "GET",
   getPath: ({ id }) => `/areas/${id}`,
   Input: {
@@ -37,7 +38,7 @@ export const CreateAreaBody = t.strict(
   "CreateAreaBody"
 );
 
-export const Create = Endpoint({
+const Create = Endpoint({
   Method: "POST",
   getPath: () => "/areas",
   Input: {
@@ -69,4 +70,12 @@ export const Delete = Endpoint({
     Params: t.type({ id: t.string }),
   },
   Output: SingleAreaOutput,
+});
+
+export const areas = ResourceEndpoints({
+  Get,
+  Create,
+  Edit,
+  List,
+  Delete,
 });

--- a/packages/@econnessione/shared/src/endpoints/article.endpoints.ts
+++ b/packages/@econnessione/shared/src/endpoints/article.endpoints.ts
@@ -4,6 +4,7 @@ import { Endpoint } from "ts-endpoint";
 import { Article } from "../io/http";
 import { Output } from "../io/http/Common/Output";
 import { GetListQuery } from "../io/http/Query";
+import { ResourceEndpoints } from "./types";
 
 export const ListArticles = Endpoint({
   Method: "GET",
@@ -42,5 +43,24 @@ export const Create = Endpoint({
       "AddActorBody"
     ),
   },
-  Output: Output(Article.Article, "Actor"),
+  Output: Output(Article.Article, "Article"),
+});
+
+export const articles = ResourceEndpoints({
+  Get,
+  List: ListArticles,
+  Create,
+  Edit: Endpoint({
+    Method: "PUT",
+    getPath: () => `/articles`,
+    Input: {
+      Body: t.unknown,
+    },
+    Output: Output(Article.Article, "Article"),
+  }),
+  Delete: Endpoint({
+    Method: "DELETE",
+    getPath: () => `/articles`,
+    Output: Output(Article.Article, "Article"),
+  }),
 });

--- a/packages/@econnessione/shared/src/endpoints/event.endpoints.ts
+++ b/packages/@econnessione/shared/src/endpoints/event.endpoints.ts
@@ -1,6 +1,7 @@
 import * as t from "io-ts";
 import { Endpoint } from "ts-endpoint";
 import * as http from "../io/http";
+import { ResourceEndpoints } from "./types";
 
 const SingleEventOutput = http.Common.Output(http.Events.Event, "Event");
 
@@ -51,4 +52,12 @@ export const Delete = Endpoint({
     Params: t.type({ id: t.string }),
   },
   Output: SingleEventOutput,
+});
+
+export const events = ResourceEndpoints({
+  Get,
+  Create,
+  List,
+  Edit,
+  Delete,
 });

--- a/packages/@econnessione/shared/src/endpoints/graph.endpoints.ts
+++ b/packages/@econnessione/shared/src/endpoints/graph.endpoints.ts
@@ -9,3 +9,7 @@ export const GetGraph = Endpoint({
   },
   Output: t.strict({ data: t.unknown }),
 });
+
+// export const graphs = ResourceEndpoints({
+//   Get: GetGraph,
+// } as any);

--- a/packages/@econnessione/shared/src/endpoints/group.endpoints.ts
+++ b/packages/@econnessione/shared/src/endpoints/group.endpoints.ts
@@ -5,6 +5,7 @@ import { nonEmptyRecordFromType } from "../io/Common/NonEmptyRecord";
 import * as http from "../io/http";
 import { ListOutput, Output } from "../io/http/Common/Output";
 import { GetListQuery } from "../io/http/Query";
+import { ResourceEndpoints } from "./types";
 
 const SingleGroupOutput = Output(http.Group.Group, "Group");
 const ListGroupOutput = ListOutput(http.Group.Group, "ListGroup");
@@ -76,4 +77,12 @@ export const Delete = Endpoint({
     Params: t.type({ id: t.string }),
   },
   Output: SingleGroupOutput,
+});
+
+export const groups = ResourceEndpoints({
+  Get,
+  Edit,
+  List,
+  Create,
+  Delete,
 });

--- a/packages/@econnessione/shared/src/endpoints/index.ts
+++ b/packages/@econnessione/shared/src/endpoints/index.ts
@@ -13,20 +13,22 @@ import * as Page from "./page.endpoints";
 import * as Project from "./project.endpoints";
 import * as Uploads from "./upload.endpoints";
 
-const endpoints = {
-  Actor,
-  Area,
-  Article,
-  Event,
-  Graph,
-  Group,
-  GroupMember,
-  Page,
-  Project,
-  ProjectImage,
-  Uploads,
-  User,
+const Endpoints = {
+  Actor: Actor.actors,
+  Area: Area.areas,
+  Article: Article.articles,
+  Event: Event.events,
+  // Graph: Graph.graphs,
+  Group: Group.groups,
+  GroupMember: GroupMember.groupMembers,
+  Page: Page.pages,
+  Project: Project.projects,
+  ProjectImage: ProjectImage.projectImages,
+  // Uploads: Uploads.uploads,
+  User: User.users,
 };
+
+type Endpoints = typeof Endpoints;
 
 const AddEndpoint = GetEndpointSubscriber((e): IOError => {
   return {
@@ -40,4 +42,6 @@ const AddEndpoint = GetEndpointSubscriber((e): IOError => {
   };
 });
 
-export { endpoints, AddEndpoint };
+export const UserLogin = User.UserLogin;
+export const PageDeleteMany = Page.DeleteManyPage;
+export { Endpoints, AddEndpoint, Uploads, Graph };

--- a/packages/@econnessione/shared/src/endpoints/page.endpoints.ts
+++ b/packages/@econnessione/shared/src/endpoints/page.endpoints.ts
@@ -3,6 +3,7 @@ import { optionFromNullable } from "io-ts-types";
 import { Endpoint } from "ts-endpoint";
 import { Page } from "../io/http";
 import { GetListQuery } from "../io/http/Query";
+import { ResourceEndpoints } from "./types";
 
 export const ListPages = Endpoint({
   Method: "GET",
@@ -68,4 +69,12 @@ export const DeleteManyPage = Endpoint({
     Query: t.partial({ ids: t.array(t.string) }),
   },
   Output: t.strict({ data: t.array(t.string) }),
+});
+
+export const pages = ResourceEndpoints({
+  Create: CreatePage,
+  Get: GetPage,
+  List: ListPages,
+  Edit: EditPage,
+  Delete: DeletePage,
 });

--- a/packages/@econnessione/shared/src/endpoints/project.endpoints.ts
+++ b/packages/@econnessione/shared/src/endpoints/project.endpoints.ts
@@ -6,6 +6,7 @@ import * as http from "../io/http";
 import { ListOutput, Output } from "../io/http/Common/Output";
 import { GetListQuery } from "../io/http/Query";
 import { CreateAreaBody } from "./area.endpoints";
+import { ResourceEndpoints } from "./types";
 
 const SingleGroupOutput = Output(http.Project.Project, "Project");
 const ListGroupOutput = ListOutput(http.Project.Project, "ListProject");
@@ -96,4 +97,12 @@ export const Delete = Endpoint({
     Params: t.type({ id: t.string }),
   },
   Output: SingleGroupOutput,
+});
+
+export const projects = ResourceEndpoints({
+  Create,
+  Get,
+  List,
+  Edit,
+  Delete,
 });

--- a/packages/@econnessione/shared/src/endpoints/types.ts
+++ b/packages/@econnessione/shared/src/endpoints/types.ts
@@ -1,11 +1,11 @@
-import { EndpointInstance } from "ts-endpoint";
+import { MinimalEndpoint } from "ts-endpoint";
 
 export interface ResourceEndpoints<
-  G extends EndpointInstance<any>,
-  L extends EndpointInstance<any>,
-  C extends EndpointInstance<any>,
-  E extends EndpointInstance<any>,
-  D extends EndpointInstance<any>
+  G extends MinimalEndpoint,
+  L extends MinimalEndpoint,
+  C extends MinimalEndpoint,
+  E extends MinimalEndpoint,
+  D extends MinimalEndpoint
 > {
   Get: G;
   List: L;
@@ -15,11 +15,11 @@ export interface ResourceEndpoints<
 }
 
 export const ResourceEndpoints = <
-  G extends EndpointInstance<any>,
-  L extends EndpointInstance<any>,
-  C extends EndpointInstance<any>,
-  E extends EndpointInstance<any>,
-  D extends EndpointInstance<any>
+  G extends MinimalEndpoint,
+  L extends MinimalEndpoint,
+  C extends MinimalEndpoint,
+  E extends MinimalEndpoint,
+  D extends MinimalEndpoint
 >(endpoints: {
   Get: G;
   List: L;

--- a/packages/@econnessione/shared/src/endpoints/upload.endpoints.ts
+++ b/packages/@econnessione/shared/src/endpoints/upload.endpoints.ts
@@ -19,3 +19,8 @@ export const GetSignedURL = Endpoint({
   },
   Output: t.strict({ data: t.string }),
 });
+
+// export const uploads = ResourceEndpoints({
+//   Get: GetSignedURL,
+//   List: 
+// });

--- a/services/api/src/routes/GroupMember/createGroupMember.controller.ts
+++ b/services/api/src/routes/GroupMember/createGroupMember.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { GroupMemberEntity } from "@entities/GroupMember.entity";
 import * as O from "fp-ts/lib/Option";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -7,7 +7,7 @@ import { Route } from "routes/route.types";
 import { toGroupMemberIO } from "./groupMember.io";
 
 export const MakeCreateGroupMemberRoute: Route = (r, { s3, db, env }) => {
-  AddEndpoint(r)(endpoints.GroupMember.Create, ({ body }) => {
+  AddEndpoint(r)(Endpoints.GroupMember.Create, ({ body }) => {
     const saveData = {
       ...body,
       group: { id: body.group },

--- a/services/api/src/routes/GroupMember/deleteGroupMember.controller.ts
+++ b/services/api/src/routes/GroupMember/deleteGroupMember.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { GroupMemberEntity } from "@entities/GroupMember.entity";
 import { Router } from "express";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -10,7 +10,7 @@ export const MakeDeleteGroupMemberRoute = (
   r: Router,
   ctx: RouteContext
 ): void => {
-  AddEndpoint(r)(endpoints.GroupMember.Delete, ({ params: { id } }) => {
+  AddEndpoint(r)(Endpoints.GroupMember.Delete, ({ params: { id } }) => {
     ctx.logger.debug.log("Delete group member %s", id);
 
     return pipe(

--- a/services/api/src/routes/GroupMember/editGroupMember.controller.ts
+++ b/services/api/src/routes/GroupMember/editGroupMember.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { GroupMemberEntity } from "@entities/GroupMember.entity";
 import { foldOptionals } from "@utils/foldOptionals.utils";
 import { Router } from "express";
@@ -11,7 +11,7 @@ export const MakeEditGroupMemberRoute = (
   r: Router,
   ctx: RouteContext
 ): void => {
-  AddEndpoint(r)(endpoints.GroupMember.Edit, ({ params: { id }, body }) => {
+  AddEndpoint(r)(Endpoints.GroupMember.Edit, ({ params: { id }, body }) => {
     ctx.logger.debug.log("Edit group member %s with %O", id, body);
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const updateData = foldOptionals(body as any);

--- a/services/api/src/routes/GroupMember/getGroupMember.controller.ts
+++ b/services/api/src/routes/GroupMember/getGroupMember.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { GroupMemberEntity } from "@entities/GroupMember.entity";
 import { Router } from "express";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -7,7 +7,7 @@ import { RouteContext } from "routes/route.types";
 import { toGroupMemberIO } from "./groupMember.io";
 
 export const MakeGetGroupMemberRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.GroupMember.Get, ({ params: { id } }) => {
+  AddEndpoint(r)(Endpoints.GroupMember.Get, ({ params: { id } }) => {
     return pipe(
       ctx.db.findOneOrFail(GroupMemberEntity, {
         where: { id },

--- a/services/api/src/routes/GroupMember/getGroupMembers.controller.ts
+++ b/services/api/src/routes/GroupMember/getGroupMembers.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { GroupMemberEntity } from "@entities/GroupMember.entity";
 import { getORMOptions } from "@utils/listQueryToORMOptions";
 import { Router } from "express";
@@ -14,7 +14,7 @@ export const MakeListGroupMemberRoute = (
   r: Router,
   ctx: RouteContext
 ): void => {
-  AddEndpoint(r)(endpoints.GroupMember.List, ({ query }) => {
+  AddEndpoint(r)(Endpoints.GroupMember.List, ({ query }) => {
     const findOptions = getORMOptions(query, ctx.env.DEFAULT_PAGE_SIZE);
 
     ctx.logger.debug.log(`find Options %O`, findOptions);

--- a/services/api/src/routes/ProjectImages/listProjectImages.controller.ts
+++ b/services/api/src/routes/ProjectImages/listProjectImages.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { ProjectImageEntity } from "@entities/ProjectImage.entity";
 import { Router } from "express";
 import { sequenceS } from "fp-ts/lib/Apply";
@@ -13,7 +13,7 @@ export const MakeListProjectImageRoute = (
   r: Router,
   ctx: RouteContext
 ): void => {
-  AddEndpoint(r)(endpoints.ProjectImage.List, () => {
+  AddEndpoint(r)(Endpoints.ProjectImage.List, () => {
     return pipe(
       sequenceS(TE.taskEither)({
         data: pipe(

--- a/services/api/src/routes/actors/createActor.controller.ts
+++ b/services/api/src/routes/actors/createActor.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { authenticationHandler } from "@utils/authenticationHandler";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/pipeable";
@@ -8,7 +8,7 @@ import { toActorIO } from "./actor.io";
 
 export const MakeCreateActorRoute: Route = (r, { db, logger }) => {
   AddEndpoint(r, authenticationHandler(logger))(
-    endpoints.Actor.Create,
+    Endpoints.Actor.Create,
     ({ body, headers }) => {
       logger.debug.log("Headers %O", { headers, body });
 

--- a/services/api/src/routes/actors/deleteActor.controller.ts
+++ b/services/api/src/routes/actors/deleteActor.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { ActorEntity } from "@entities/Actor.entity";
 import { ServerError } from "@io/ControllerError";
 import { sequenceS } from "fp-ts/lib/Apply";
@@ -8,7 +8,7 @@ import { Route } from "routes/route.types";
 import { toActorIO } from "./actor.io";
 
 export const MakeDeleteActorRoute: Route = (r, { s3, db, env }) => {
-  AddEndpoint(r)(endpoints.Actor.Delete, ({ params: { id } }) => {
+  AddEndpoint(r)(Endpoints.Actor.Delete, ({ params: { id } }) => {
     return pipe(
       db.findOneOrFail(ActorEntity, {
         where: { id },

--- a/services/api/src/routes/actors/editActor.controller.ts
+++ b/services/api/src/routes/actors/editActor.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { ActorEntity } from "@entities/Actor.entity";
 import { foldOptionals } from "@utils/foldOptionals.utils";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -7,7 +7,7 @@ import { Route } from "routes/route.types";
 import { toActorIO } from "./actor.io";
 
 export const MakeEditActorRoute: Route = (r, { s3, db, env, logger }) => {
-  AddEndpoint(r)(endpoints.Actor.Edit, ({ params: { id }, body }) => {
+  AddEndpoint(r)(Endpoints.Actor.Edit, ({ params: { id }, body }) => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const updateData = foldOptionals(body as any);
     logger.debug.log("Actor update data %O", updateData);

--- a/services/api/src/routes/actors/getActor.controller.ts
+++ b/services/api/src/routes/actors/getActor.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { Router } from "express";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/pipeable";
@@ -7,7 +7,7 @@ import { ActorEntity } from "../../entities/Actor.entity";
 import { toActorIO } from "./actor.io";
 
 export const MakeGetActorRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Actor.Get, ({ params: { id } }) => {
+  AddEndpoint(r)(Endpoints.Actor.Get, ({ params: { id } }) => {
     return pipe(
       ctx.db.findOneOrFail(ActorEntity, {
         where: { id },

--- a/services/api/src/routes/actors/listActor.controller.ts
+++ b/services/api/src/routes/actors/listActor.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { getORMOptions } from "@utils/listQueryToORMOptions";
 import { Router } from "express";
 import { sequenceS } from "fp-ts/lib/Apply";
@@ -11,7 +11,7 @@ import { ActorEntity } from "../../entities/Actor.entity";
 import { toActorIO } from "./actor.io";
 
 export const MakeListPageRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Actor.List, ({ query: { ids, ...query } }) => {
+  AddEndpoint(r)(Endpoints.Actor.List, ({ query: { ids, ...query } }) => {
     const findOptions = getORMOptions(
       { ...query, id: ids },
       ctx.env.DEFAULT_PAGE_SIZE

--- a/services/api/src/routes/areas/createArea.controller.ts
+++ b/services/api/src/routes/areas/createArea.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { authenticationHandler } from "@utils/authenticationHandler";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/pipeable";
@@ -8,7 +8,7 @@ import { toAreaIO } from "./Area.io";
 
 export const MakeCreateAreaRoute: Route = (r, { db, logger }) => {
   AddEndpoint(r, authenticationHandler(logger))(
-    endpoints.Area.Create,
+    Endpoints.Area.Create,
     ({ body, headers }) => {
       logger.debug.log("Headers %O", { headers, body });
 

--- a/services/api/src/routes/areas/deleteArea.controller.ts
+++ b/services/api/src/routes/areas/deleteArea.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { AreaEntity } from "@entities/Area.entity";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/pipeable";
@@ -6,7 +6,7 @@ import { Route } from "routes/route.types";
 import { toAreaIO } from "./Area.io";
 
 export const MakeDeleteAreaRoute: Route = (r, { s3, db, env }) => {
-  AddEndpoint(r)(endpoints.Area.Delete, ({ params: { id } }) => {
+  AddEndpoint(r)(Endpoints.Area.Delete, ({ params: { id } }) => {
     return pipe(
       db.findOneOrFail(AreaEntity, {
         where: { id },

--- a/services/api/src/routes/areas/editArea.controller.ts
+++ b/services/api/src/routes/areas/editArea.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { AreaEntity } from "@entities/Area.entity";
 import { foldOptionals } from "@utils/foldOptionals.utils";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -7,7 +7,7 @@ import { Route } from "routes/route.types";
 import { toAreaIO } from "./Area.io";
 
 export const MakeEditAreaRoute: Route = (r, { s3, db, env, logger }) => {
-  AddEndpoint(r)(endpoints.Area.Edit, ({ params: { id }, body }) => {
+  AddEndpoint(r)(Endpoints.Area.Edit, ({ params: { id }, body }) => {
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const updateData = foldOptionals(body as any);
     logger.debug.log("Actor update data %O", updateData);

--- a/services/api/src/routes/areas/getArea.controller.ts
+++ b/services/api/src/routes/areas/getArea.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { AreaEntity } from "@entities/Area.entity";
 import { NotFoundError } from "@io/ControllerError";
 import { Router } from "express";
@@ -8,7 +8,7 @@ import { RouteContext } from "routes/route.types";
 import { toAreaIO } from "./Area.io";
 
 export const MakeGetAreaRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Area.Get, ({ params: { id } }) => {
+  AddEndpoint(r)(Endpoints.Area.Get, ({ params: { id } }) => {
     return pipe(
       ctx.db.findOneOrFail(AreaEntity, {
         where: { id },

--- a/services/api/src/routes/areas/listArea.controller.ts
+++ b/services/api/src/routes/areas/listArea.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { AreaEntity } from "@entities/Area.entity";
 import { getORMOptions } from "@utils/listQueryToORMOptions";
 import { Router } from "express";
@@ -11,7 +11,7 @@ import { RouteContext } from "routes/route.types";
 import { toAreaIO } from "./Area.io";
 
 export const MakeListAreaRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Area.List, ({ query }) => {
+  AddEndpoint(r)(Endpoints.Area.List, ({ query }) => {
     const findOptions = getORMOptions(query, ctx.env.DEFAULT_PAGE_SIZE);
     return pipe(
       sequenceS(TE.taskEither)({

--- a/services/api/src/routes/articles/createArticle.controller.ts
+++ b/services/api/src/routes/articles/createArticle.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { ArticleEntity } from "@entities/Article.entity";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/pipeable";
@@ -6,7 +6,7 @@ import { Route } from "routes/route.types";
 import { toArticleIO } from "./article.io";
 
 export const MakeCreateArticleRoute: Route = (r, ctx) => {
-  AddEndpoint(r)(endpoints.Article.Create, ({ body: { avatar, ...body } }) => {
+  AddEndpoint(r)(Endpoints.Article.Create, ({ body: { avatar, ...body } }) => {
     return pipe(
       ctx.db.save(ArticleEntity, [body]),
       TE.map((articles) => articles[0]),

--- a/services/api/src/routes/articles/getArticle.controller.ts
+++ b/services/api/src/routes/articles/getArticle.controller.ts
@@ -1,11 +1,11 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { ArticleEntity } from "@entities/Article.entity";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/pipeable";
 import { Route } from "routes/route.types";
 
 export const MakeGetArticleRoute: Route = (r, ctx) => {
-  AddEndpoint(r)(endpoints.Article.Get, ({ params: { id } }) => {
+  AddEndpoint(r)(Endpoints.Article.Get, ({ params: { id } }) => {
     // console.log('here')
     return pipe(
       ctx.db.findOneOrFail(ArticleEntity, { where: { id } }),

--- a/services/api/src/routes/articles/listArticles.controller.ts
+++ b/services/api/src/routes/articles/listArticles.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { ArticleEntity } from "@entities/Article.entity";
 import { getORMOptions } from "@utils/listQueryToORMOptions";
 import { sequenceS } from "fp-ts/lib/Apply";
@@ -10,7 +10,7 @@ import { Route } from "routes/route.types";
 import { toArticleIO } from "./article.io";
 
 export const MakeListArticlesRoute: Route = (r, { env, db }) => {
-  AddEndpoint(r)(endpoints.Article.ListArticles, ({ query }) => {
+  AddEndpoint(r)(Endpoints.Article.List, ({ query }) => {
     const findOptions = getORMOptions(query, env.DEFAULT_PAGE_SIZE);
     return pipe(
       sequenceS(TE.taskEither)({

--- a/services/api/src/routes/events/createEvent.controller.ts
+++ b/services/api/src/routes/events/createEvent.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { EventEntity } from "@entities/Event.entity";
 import { foldOptionals } from "@utils/foldOptionals.utils";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -8,7 +8,7 @@ import { toEventIO } from "./event.io";
 
 export const MakeCreateEventRoute: Route = (r, { s3, db, env }) => {
   AddEndpoint(r)(
-    endpoints.Event.Create,
+    Endpoints.Event.Create,
     ({ body: { endDate, images, ...body } }) => {
       const optionalData = pipe(foldOptionals({ endDate }), (data) => ({
         ...data,

--- a/services/api/src/routes/events/editEvent.controller.ts
+++ b/services/api/src/routes/events/editEvent.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { uuid } from "@econnessione/shared/utils/uuid";
 import { EventEntity } from "@entities/Event.entity";
 import { foldOptionals } from "@utils/foldOptionals.utils";
@@ -12,7 +12,7 @@ import { toEventIO } from "./event.io";
 
 export const MakeEditEventRoute = (r: Router, ctx: RouteContext): void => {
   AddEndpoint(r)(
-    endpoints.Event.Edit,
+    Endpoints.Event.Edit,
     ({
       params: { id },
       body: { links, images, actors, groups, groupsMembers, ...body },

--- a/services/api/src/routes/events/getEvent.controller.ts
+++ b/services/api/src/routes/events/getEvent.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { EventEntity } from "@entities/Event.entity";
 import { Router } from "express";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -7,7 +7,7 @@ import { RouteContext } from "routes/route.types";
 import { toEventIO } from "./event.io";
 
 export const MakeGetEventRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Event.Get, ({ params: { id } }) => {
+  AddEndpoint(r)(Endpoints.Event.Get, ({ params: { id } }) => {
     const selectEventTask = pipe(
       ctx.db.manager
         .createQueryBuilder(EventEntity, "event")

--- a/services/api/src/routes/events/getEvents.controller.ts
+++ b/services/api/src/routes/events/getEvents.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { EventEntity } from "@entities/Event.entity";
 import { getORMOptions } from "@utils/listQueryToORMOptions";
 import { Router } from "express";
@@ -14,7 +14,7 @@ import { toEventIO } from "./event.io";
 
 export const MakeListEventRoute = (r: Router, ctx: RouteContext): void => {
   AddEndpoint(r)(
-    endpoints.Event.List,
+    Endpoints.Event.List,
     ({ query: { actors, groups, ...query } }) => {
       ctx.logger.info.log("Query %O", query);
       const findOptions = getORMOptions(

--- a/services/api/src/routes/graphs/getGraph.controller.ts
+++ b/services/api/src/routes/graphs/getGraph.controller.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs";
 import * as path from "path";
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Graph, AddEndpoint } from "@econnessione/shared/endpoints";
 import { Router } from "express";
 import * as E from "fp-ts/lib/Either";
 import * as IOE from "fp-ts/lib/IOEither";
@@ -23,7 +23,7 @@ const readFile = (id: string): TE.TaskEither<Error, string> =>
   );
 
 export const MakeGraphsRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Graph.GetGraph, ({ params: { id } }) => {
+  AddEndpoint(r)(Graph.GetGraph, ({ params: { id } }) => {
     return pipe(
       readFile(id),
       TE.mapLeft(

--- a/services/api/src/routes/groups/createGroup.controller.ts
+++ b/services/api/src/routes/groups/createGroup.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/pipeable";
 import { Route } from "routes/route.types";
@@ -6,7 +6,7 @@ import { ActorEntity } from "../../entities/Actor.entity";
 import { GroupEntity } from "../../entities/Group.entity";
 
 export const MakeCreateGroupRoute: Route = (r, { s3, db, env }) => {
-  AddEndpoint(r)(endpoints.Group.Create, ({ body: { color, ...body } }) => {
+  AddEndpoint(r)(Endpoints.Group.Create, ({ body: { color, ...body } }) => {
     return pipe(
       db.save(GroupEntity, [
         {

--- a/services/api/src/routes/groups/editGroup.controller.ts
+++ b/services/api/src/routes/groups/editGroup.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { Router } from "express";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/pipeable";
@@ -7,7 +7,7 @@ import { GroupEntity } from "../../entities/Group.entity";
 
 export const MakeEditGroupRoute = (r: Router, ctx: RouteContext): void => {
   AddEndpoint(r)(
-    endpoints.Group.Edit,
+    Endpoints.Group.Edit,
     ({ params: { id }, body: { avatar, ...body } }) => {
       return pipe(
         ctx.db.update(GroupEntity, id, { ...body, avatar }),

--- a/services/api/src/routes/groups/getGroup.controller.ts
+++ b/services/api/src/routes/groups/getGroup.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { Router } from "express";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/pipeable";
@@ -7,7 +7,7 @@ import { GroupEntity } from "../../entities/Group.entity";
 import { toGroupIO } from "./group.io";
 
 export const MakeGetGroupRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Group.Get, ({ params: { id } }) => {
+  AddEndpoint(r)(Endpoints.Group.Get, ({ params: { id } }) => {
     return pipe(
       ctx.db.findOneOrFail(GroupEntity, {
         where: { id },

--- a/services/api/src/routes/groups/getGroups.controller.ts
+++ b/services/api/src/routes/groups/getGroups.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { getORMOptions } from "@utils/listQueryToORMOptions";
 import { Router } from "express";
 import { sequenceS } from "fp-ts/lib/Apply";
@@ -11,7 +11,7 @@ import { GroupEntity } from "../../entities/Group.entity";
 import { toGroupIO } from "./group.io";
 
 export const MakeListGroupRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Group.List, ({ query: { ids, ...query } }) => {
+  AddEndpoint(r)(Endpoints.Group.List, ({ query: { ids, ...query } }) => {
     return pipe(
       sequenceS(TE.taskEither)({
         data: pipe(

--- a/services/api/src/routes/pages/addPage.controller.ts
+++ b/services/api/src/routes/pages/addPage.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { Router } from "express";
 import { sequenceS } from "fp-ts/lib/Apply";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -7,7 +7,7 @@ import { RouteContext } from "routes/route.types";
 import { PageEntity } from "../../entities/Page.entity";
 
 export const MakeAddPageRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Page.CreatePage, ({ body }) => {
+  AddEndpoint(r)(Endpoints.Page.Create, ({ body }) => {
     return pipe(
       ctx.db.save(PageEntity, [body]),
       TE.chain(([page]) =>

--- a/services/api/src/routes/pages/deleteManyPage.controller.ts
+++ b/services/api/src/routes/pages/deleteManyPage.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { PageDeleteMany, AddEndpoint } from "@econnessione/shared/endpoints";
 import { Router } from "express";
 import * as TE from "fp-ts/lib/TaskEither";
 import { pipe } from "fp-ts/lib/pipeable";
@@ -7,7 +7,7 @@ import { In } from "typeorm";
 import { PageEntity } from "../../entities/Page.entity";
 
 export const MakeDeleteManyPageRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Page.DeleteManyPage, ({ query: { ids } }) => {
+  AddEndpoint(r)(PageDeleteMany, ({ query: { ids } }) => {
     return pipe(
       ctx.db.find(PageEntity, { where: { uuid: In(ids) } }),
       TE.chainFirst(() => ctx.db.delete(PageEntity, ids)),

--- a/services/api/src/routes/pages/deletePage.controller.ts
+++ b/services/api/src/routes/pages/deletePage.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { NotFoundError } from "@io/ControllerError";
 import { Router } from "express";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -7,7 +7,7 @@ import { RouteContext } from "routes/route.types";
 import { PageEntity } from "../../entities/Page.entity";
 
 export const MakeDeletePageRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Page.DeletePage, ({ params: { id } }) => {
+  AddEndpoint(r)(Endpoints.Page.Delete, ({ params: { id } }) => {
     return pipe(
       ctx.db.findOne(PageEntity, { where: { id } }),
       TE.chain(TE.fromOption(() => NotFoundError("Page"))),

--- a/services/api/src/routes/pages/editPage.controller.ts
+++ b/services/api/src/routes/pages/editPage.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { NotFoundError } from "@io/ControllerError";
 import { Router } from "express";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -7,7 +7,7 @@ import { RouteContext } from "routes/route.types";
 import { PageEntity } from "../../entities/Page.entity";
 
 export const MakeEditPageRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Page.EditPage, ({ params: { id }, body }) => {
+  AddEndpoint(r)(Endpoints.Page.Edit, ({ params: { id }, body }) => {
     return pipe(
       ctx.db.update(PageEntity, id, body),
       TE.chain(() => ctx.db.findOne(PageEntity, { where: { id } })),

--- a/services/api/src/routes/pages/getPage.controller.ts
+++ b/services/api/src/routes/pages/getPage.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { NotFoundError } from "@io/ControllerError";
 import { Router } from "express";
 import { sequenceS } from "fp-ts/lib/Apply";
@@ -8,7 +8,7 @@ import { RouteContext } from "routes/route.types";
 import { PageEntity } from "../../entities/Page.entity";
 
 export const MakeGetPageRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Page.GetPage, ({ params: { id } }) => {
+  AddEndpoint(r)(Endpoints.Page.Get, ({ params: { id } }) => {
     return pipe(
       ctx.db.findOne(PageEntity, { where: { id } }),
       TE.chain(TE.fromOption(() => NotFoundError("Page"))),

--- a/services/api/src/routes/pages/listPage.controller.ts
+++ b/services/api/src/routes/pages/listPage.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { getORMOptions } from "@utils/listQueryToORMOptions";
 import { Router } from "express";
 import { sequenceS } from "fp-ts/lib/Apply";
@@ -8,7 +8,7 @@ import { RouteContext } from "routes/route.types";
 import { PageEntity } from "../../entities/Page.entity";
 
 export const MakeListPageRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Page.ListPages, ({ query }) => {
+  AddEndpoint(r)(Endpoints.Page.List, ({ query }) => {
     return pipe(
       sequenceS(TE.taskEither)({
         data: ctx.db.find(PageEntity, {

--- a/services/api/src/routes/projects/createProject.controller.ts
+++ b/services/api/src/routes/projects/createProject.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { uuid } from "@econnessione/shared/utils/uuid";
 import { ProjectEntity } from "@entities/Project.entity";
 import { ProjectImageEntity } from "@entities/ProjectImage.entity";
@@ -10,7 +10,7 @@ import { Route } from "routes/route.types";
 
 export const MakeCreateProjectRoute: Route = (r, { db, env }) => {
   AddEndpoint(r)(
-    endpoints.Project.Create,
+    Endpoints.Project.Create,
     ({ body: { endDate, images, ...body } }) => {
       const optionalData = foldOptionals({ endDate });
       return pipe(

--- a/services/api/src/routes/projects/editProject.controller.ts
+++ b/services/api/src/routes/projects/editProject.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { uuid } from "@econnessione/shared/utils/uuid";
 import { ProjectEntity } from "@entities/Project.entity";
 import { foldOptionals } from "@utils/foldOptionals.utils";
@@ -10,7 +10,7 @@ import { RouteContext } from "routes/route.types";
 import { toProjectIO } from "./project.io";
 
 export const MakeEditProjectRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Project.Edit, ({ params: { id }, body }) => {
+  AddEndpoint(r)(Endpoints.Project.Edit, ({ params: { id }, body }) => {
     const projectData = foldOptionals({
       ...body,
       areas: pipe(

--- a/services/api/src/routes/projects/getProject.controller.ts
+++ b/services/api/src/routes/projects/getProject.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { ProjectEntity } from "@entities/Project.entity";
 import { Router } from "express";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -7,7 +7,7 @@ import { RouteContext } from "routes/route.types";
 import { toProjectIO } from "./project.io";
 
 export const MakeGetProjectRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Project.Get, ({ params: { id } }) => {
+  AddEndpoint(r)(Endpoints.Project.Get, ({ params: { id } }) => {
     return pipe(
       ctx.db.findOneOrFail(ProjectEntity, {
         where: { id },

--- a/services/api/src/routes/projects/getProjects.controller.ts
+++ b/services/api/src/routes/projects/getProjects.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { ProjectEntity } from "@entities/Project.entity";
 import { Router } from "express";
 import { sequenceS } from "fp-ts/lib/Apply";
@@ -11,7 +11,7 @@ import { getORMOptions } from "../../utils/listQueryToORMOptions";
 import { toProjectIO } from "./project.io";
 
 export const MakeListProjectRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.Project.List, ({ query }) => {
+  AddEndpoint(r)(Endpoints.Project.List, ({ query }) => {
     const findOptions = getORMOptions(query, ctx.env.DEFAULT_PAGE_SIZE);
     return pipe(
       sequenceS(TE.taskEither)({

--- a/services/api/src/routes/uploads/getSignedURL.controller.ts
+++ b/services/api/src/routes/uploads/getSignedURL.controller.ts
@@ -1,4 +1,5 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { AddEndpoint } from "@econnessione/shared/endpoints";
+import { GetSignedURL } from "@econnessione/shared/endpoints/upload.endpoints";
 import { uuid } from "@econnessione/shared/utils/uuid";
 import { Router } from "express";
 import * as TE from "fp-ts/lib/TaskEither";
@@ -18,7 +19,7 @@ const fileExtFromContentType = (c: string): string => {
 
 export const MakeSignedUrlRoute = (r: Router, ctx: RouteContext): void => {
   AddEndpoint(r)(
-    endpoints.Uploads.GetSignedURL,
+    GetSignedURL,
     ({ body: { resource, resourceId, ContentType } }) => {
       return pipe(
         ctx.s3.getSignedUrl("putObject", {

--- a/services/api/src/routes/users/userCreate.controller.ts
+++ b/services/api/src/routes/users/userCreate.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { uuid } from "@econnessione/shared/utils/uuid";
 import { UserEntity } from "@entities/User.entity";
 import { RouteContext } from "@routes/route.types";
@@ -10,7 +10,7 @@ import { toUserIO } from "./user.io";
 
 export const MakeUserCreateRoute = (r: Router, ctx: RouteContext): void => {
   AddEndpoint(r)(
-    endpoints.User.UserCreate,
+    Endpoints.User.Create,
     ({ body: { password, ...userData } }) => {
       ctx.logger.debug.log("Login user with username or email %O", userData);
       return pipe(

--- a/services/api/src/routes/users/userList.controller.ts
+++ b/services/api/src/routes/users/userList.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { Endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
 import { UserEntity } from "@entities/User.entity";
 import { RouteContext } from "@routes/route.types";
 import { getORMOptions } from "@utils/listQueryToORMOptions";
@@ -11,7 +11,7 @@ import { pipe } from "fp-ts/lib/pipeable";
 import { toUserIO } from "./user.io";
 
 export const MakeUserListRoute = (r: Router, ctx: RouteContext): void => {
-  AddEndpoint(r)(endpoints.User.UserList, ({ query }) => {
+  AddEndpoint(r)(Endpoints.User.List, ({ query }) => {
     const findOptions = getORMOptions(query, ctx.env.DEFAULT_PAGE_SIZE);
     return pipe(
       sequenceS(TE.taskEither)({

--- a/services/api/src/routes/users/userLogin.controller.ts
+++ b/services/api/src/routes/users/userLogin.controller.ts
@@ -1,4 +1,4 @@
-import { endpoints, AddEndpoint } from "@econnessione/shared/endpoints";
+import { UserLogin, AddEndpoint } from "@econnessione/shared/endpoints";
 import { UserEntity } from "@entities/User.entity";
 import { BadRequestError } from "@io/ControllerError";
 import { RouteContext } from "@routes/route.types";
@@ -9,7 +9,7 @@ import { pipe } from "fp-ts/lib/pipeable";
 
 export const MakeUserLoginRoute = (r: Router, ctx: RouteContext): void => {
   AddEndpoint(r)(
-    endpoints.User.UserLogin,
+    UserLogin,
     ({ body: { username, password } }) => {
       ctx.logger.debug.log("Login user with username or email %s", username);
       return pipe(

--- a/services/web/src/pages/ActorsPage.tsx
+++ b/services/web/src/pages/ActorsPage.tsx
@@ -6,7 +6,7 @@ import { PageContent } from "@econnessione/shared/components/PageContent";
 import SEO from "@econnessione/shared/components/SEO";
 import SearchableInput from "@econnessione/shared/components/SearchableInput";
 import {
-  actorsList,
+  Queries,
   pageContentByPath,
 } from "@econnessione/shared/providers/DataProvider";
 import { navigateTo } from "@econnessione/shared/utils/links";
@@ -19,9 +19,12 @@ export default class ActorsPage extends React.PureComponent<RouteComponentProps>
   render(): JSX.Element {
     return (
       <WithQueries
-        queries={{ actorsList, pageContent: pageContentByPath }}
+        queries={{
+          actors: Queries.Actor.getList,
+          pageContent: pageContentByPath,
+        }}
         params={{
-          actorsList: {
+          actors: {
             pagination: { page: 1, perPage: 20 },
             sort: { field: "id", order: "ASC" },
             filter: {},
@@ -33,7 +36,7 @@ export default class ActorsPage extends React.PureComponent<RouteComponentProps>
         render={QR.fold(
           LazyFullSizeLoader,
           ErrorBox,
-          ({ actorsList: { data: acts }, pageContent }) => (
+          ({ actors: { data: acts }, pageContent }) => (
             <>
               <SEO title={pageContent.title} />
               <MainContent>

--- a/services/web/src/pages/BlogPage.tsx
+++ b/services/web/src/pages/BlogPage.tsx
@@ -5,7 +5,7 @@ import { MainContent } from "@econnessione/shared/components/MainContent";
 import { PageContent } from "@econnessione/shared/components/PageContent";
 import SEO from "@econnessione/shared/components/SEO";
 import {
-  articlesList,
+  Queries,
   pageContentByPath,
 } from "@econnessione/shared/providers/DataProvider";
 import {
@@ -44,9 +44,9 @@ export default class BlogPage extends React.PureComponent<RouteComponentProps> {
             ))}
           />
           <WithQueries
-            queries={{ articlesList }}
+            queries={{ articles: Queries.Article.getList }}
             params={{
-              articlesList: {
+              articles: {
                 pagination: { page: 1, perPage: 20 },
                 sort: { field: "id", order: "DESC" },
                 filter: { draft: true },
@@ -55,48 +55,52 @@ export default class BlogPage extends React.PureComponent<RouteComponentProps> {
             render={QR.fold(
               LazyFullSizeLoader,
               ErrorBox,
-              ({ articlesList: { data: articles } }) => (
-                <div>
-                  <Grid container spacing={2} style={{ marginBottom: 100 }}>
-                    {articles.map((a) => (
-                      <Grid item key={a.id} xs={6}>
-                        <Card key={a.id}>
-                          <CardHeader
-                            title={a.title}
-                            subheader={
-                              <p style={{ fontSize: 11 }}>
-                                {formatDate(a.createdAt)}
-                              </p>
-                            }
-                          />
-                          <CardActionArea>
-                            <CardMedia
-                              component="img"
-                              alt="Contemplative Reptile"
-                              height="140"
-                              image={a.featuredImage}
-                              title="Contemplative Reptile"
+              ({ articles: { data: articles } }) => {
+                // eslint-disable-next-line
+                console.log(articles);
+                return (
+                  <div>
+                    <Grid container spacing={2} style={{ marginBottom: 100 }}>
+                      {articles.map((a) => (
+                        <Grid item key={a.id} xs={6}>
+                          <Card key={a.id}>
+                            <CardHeader
+                              title={a.title}
+                              subheader={
+                                <p style={{ fontSize: 11 }}>
+                                  {formatDate(a.createdAt)}
+                                </p>
+                              }
                             />
-                          </CardActionArea>
-                          <CardActions>
-                            <Button
-                              size="small"
-                              color="primary"
-                              onClick={async () => {
-                                if (navigate) {
-                                  await navigate(`/blog/${a.id}`);
-                                }
-                              }}
-                            >
-                              Leggi
-                            </Button>
-                          </CardActions>
-                        </Card>
-                      </Grid>
-                    ))}
-                  </Grid>
-                </div>
-              )
+                            <CardActionArea>
+                              <CardMedia
+                                component="img"
+                                alt="Contemplative Reptile"
+                                height="140"
+                                image={a.featuredImage}
+                                title="Contemplative Reptile"
+                              />
+                            </CardActionArea>
+                            <CardActions>
+                              <Button
+                                size="small"
+                                color="primary"
+                                onClick={async () => {
+                                  if (navigate) {
+                                    await navigate(`/blog/${a.id}`);
+                                  }
+                                }}
+                              >
+                                Leggi
+                              </Button>
+                            </CardActions>
+                          </Card>
+                        </Grid>
+                      ))}
+                    </Grid>
+                  </div>
+                );
+              }
             )}
           />
         </MainContent>

--- a/services/web/src/pages/EventsPage.tsx
+++ b/services/web/src/pages/EventsPage.tsx
@@ -19,9 +19,7 @@ import {
 import * as io from "@econnessione/shared/io";
 import { Actor, Group, Topic } from "@econnessione/shared/io/http";
 import {
-  actorsList,
-  eventsList,
-  groupsList,
+  Queries,
   pageContentByPath,
 } from "@econnessione/shared/providers/DataProvider";
 import { GetByGroupOrActorUtils } from "@econnessione/shared/utils/ByGroupOrActorUtils";
@@ -50,9 +48,10 @@ export default class EventsPage extends React.PureComponent<RouteComponentProps>
       <WithQueries
         queries={{
           page: pageContentByPath,
-          actors: actorsList,
-          groups: groupsList,
-          events: eventsList,
+          actors: Queries.Actor.getList,
+          groups: Queries.Group.getList,
+          events: Queries.Event.getList,
+          deaths: Queries.Event.getList,
         }}
         params={{
           page: {
@@ -71,6 +70,11 @@ export default class EventsPage extends React.PureComponent<RouteComponentProps>
           events: {
             pagination: { page: 1, perPage: 100 },
             sort: { field: "startDate", order: "DESC" },
+            filter: {},
+          },
+          deaths: {
+            pagination: { page: 1, perPage: 20 },
+            sort: { field: "date", order: "DESC" },
             filter: {},
           },
         }}

--- a/services/web/src/pages/GroupsPage.tsx
+++ b/services/web/src/pages/GroupsPage.tsx
@@ -7,7 +7,7 @@ import GroupList, {
   GroupListItem,
 } from "@econnessione/shared/components/lists/GroupList";
 import {
-  groupsList,
+  Queries,
   pageContentByPath,
 } from "@econnessione/shared/providers/DataProvider";
 import { navigateTo } from "@econnessione/shared/utils/links";
@@ -21,7 +21,7 @@ export default class GroupsPage extends React.PureComponent<RouteComponentProps>
     return (
       <WithQueries
         queries={{
-          groups: groupsList,
+          groups: Queries.Group.getList,
           pageContent: pageContentByPath,
         }}
         params={{

--- a/services/web/src/pages/ProjectsPage.tsx
+++ b/services/web/src/pages/ProjectsPage.tsx
@@ -9,7 +9,7 @@ import { TableOfContents } from "@econnessione/shared/components/TableOfContents
 import ProjectList from "@econnessione/shared/components/lists/ProjectList";
 import {
   pageContentByPath,
-  projectList,
+  Queries,
 } from "@econnessione/shared/providers/DataProvider";
 import { TextField } from "@material-ui/core";
 import Autocomplete from "@material-ui/lab/Autocomplete";
@@ -24,7 +24,7 @@ export default class ProjectsPage extends React.PureComponent<RouteComponentProp
   render(): JSX.Element {
     return (
       <WithQueries
-        queries={{ page: pageContentByPath, projects: projectList }}
+        queries={{ page: pageContentByPath, projects: Queries.Project.getList }}
         params={{
           page: { path: "projects" },
           projects: {

--- a/services/web/src/pages/TopicsPage.tsx
+++ b/services/web/src/pages/TopicsPage.tsx
@@ -7,7 +7,7 @@ import SearchableInput from "@econnessione/shared/components/SearchableInput";
 import { TopicListItem } from "@econnessione/shared/components/lists/TopicList";
 import {
   pageContentByPath,
-  topicsList,
+  Queries,
 } from "@econnessione/shared/providers/DataProvider";
 import { navigateTo } from "@econnessione/shared/utils/links";
 import { RouteComponentProps } from "@reach/router";
@@ -21,55 +21,50 @@ export default class TopicsPage extends React.PureComponent<RouteComponentProps>
       <WithQueries
         queries={{
           pageContent: pageContentByPath,
-          topics: topicsList,
         }}
         params={{
           pageContent: {
             path: "topics",
           },
-          topics: {
-            pagination: { page: 1, perPage: 20 },
-            sort: { field: "id", order: "ASC" },
-            filter: {},
-          },
+          // topics: {
+          //   pagination: { page: 1, perPage: 20 },
+          //   sort: { field: "id", order: "ASC" },
+          //   filter: {},
+          // },
         }}
-        render={QR.fold(
-          Loader,
-          ErrorBox,
-          ({ pageContent, topics: { data: topics } }) => (
-            <>
-              <SEO title={pageContent.title} />
-              <MainContent>
-                <PageContent {...pageContent} />
-                <SearchableInput
-                  items={topics.map((t) => ({
-                    ...t.frontmatter,
-                    selected: false,
-                  }))}
-                  selectedItems={[]}
-                  getValue={(t) => t.label}
-                  itemRenderer={(item, props, index) => (
-                    <TopicListItem
-                      item={item}
-                      index={index}
-                      onClick={async (t: any) => {
-                        if (this.props.navigate !== undefined) {
-                          await navigateTo(this.props.navigate, "topics", t);
-                        }
-                      }}
-                    />
-                  )}
-                  onSelectItem={async (item) => {
-                    if (this.props.navigate !== undefined) {
-                      await navigateTo(this.props.navigate, "topics", item);
-                    }
-                  }}
-                  onUnselectItem={() => {}}
-                />
-              </MainContent>
-            </>
-          )
-        )}
+        render={QR.fold(Loader, ErrorBox, ({ pageContent }) => (
+          <>
+            <SEO title={pageContent.title} />
+            <MainContent>
+              <PageContent {...pageContent} />
+              <SearchableInput
+                items={[].map((t: any) => ({
+                  ...t.frontmatter,
+                  selected: false,
+                }))}
+                selectedItems={[]}
+                getValue={(t) => t.label}
+                itemRenderer={(item, props, index) => (
+                  <TopicListItem
+                    item={item}
+                    index={index}
+                    onClick={async (t: any) => {
+                      if (this.props.navigate !== undefined) {
+                        await navigateTo(this.props.navigate, "topics", t);
+                      }
+                    }}
+                  />
+                )}
+                onSelectItem={async (item) => {
+                  if (this.props.navigate !== undefined) {
+                    await navigateTo(this.props.navigate, "topics", item);
+                  }
+                }}
+                onUnselectItem={() => {}}
+              />
+            </MainContent>
+          </>
+        ))}
       />
     );
   }

--- a/services/web/src/templates/ActorTemplate.tsx
+++ b/services/web/src/templates/ActorTemplate.tsx
@@ -5,7 +5,7 @@ import { MainContent } from "@econnessione/shared/components/MainContent";
 import SEO from "@econnessione/shared/components/SEO";
 import { EventSlider } from "@econnessione/shared/components/sliders/EventSlider";
 import { eventMetadataMapEmpty } from "@econnessione/shared/mock-data/events/events-metadata";
-import { actor } from "@econnessione/shared/providers/DataProvider";
+import { Queries } from "@econnessione/shared/providers/DataProvider";
 import { RouteComponentProps } from "@reach/router";
 import * as QR from "avenger/lib/QueryResult";
 import { WithQueries } from "avenger/lib/react";
@@ -25,7 +25,7 @@ export default class ActorTemplate extends React.PureComponent<
         () => <div>Missing project id</div>,
         (actorId) => (
           <WithQueries
-            queries={{ actor: actor }}
+            queries={{ actor: Queries.Actor.get }}
             params={{
               actor: { id: actorId },
             }}

--- a/services/web/src/templates/AreaTemplate.tsx
+++ b/services/web/src/templates/AreaTemplate.tsx
@@ -3,7 +3,7 @@ import { ErrorBox } from "@econnessione/shared/components/Common/ErrorBox";
 import { Loader } from "@econnessione/shared/components/Common/Loader";
 import { MainContent } from "@econnessione/shared/components/MainContent";
 import SEO from "@econnessione/shared/components/SEO";
-import { area } from "@econnessione/shared/providers/DataProvider";
+import { Queries } from "@econnessione/shared/providers/DataProvider";
 import { RouteComponentProps } from "@reach/router";
 import * as QR from "avenger/lib/QueryResult";
 import { WithQueries } from "avenger/lib/react";
@@ -23,7 +23,7 @@ export default class AreaTemplate extends React.PureComponent<
         () => <div>Missing project id</div>,
         (areaId) => (
           <WithQueries
-            queries={{ area: area }}
+            queries={{ area: Queries.Area.get }}
             params={{ area: { id: areaId } }}
             render={QR.fold(Loader, ErrorBox, ({ area }) => {
               return (

--- a/services/web/src/templates/ArticleTemplate.tsx
+++ b/services/web/src/templates/ArticleTemplate.tsx
@@ -1,14 +1,8 @@
 import { LazyFullSizeLoader } from "@components/Common/FullSizeLoader";
 import { ArticlePageContent } from "@econnessione/shared/components/ArticlePageContent";
 import { ErrorBox } from "@econnessione/shared/components/Common/ErrorBox";
-import { Loader } from "@econnessione/shared/components/Common/Loader";
-import { MainContent } from "@econnessione/shared/components/MainContent";
 import SEO from "@econnessione/shared/components/SEO";
-import {
-  article,
-  articleByPath,
-} from "@econnessione/shared/providers/DataProvider";
-import { Grid } from "@material-ui/core";
+import { articleByPath } from "@econnessione/shared/providers/DataProvider";
 import { RouteComponentProps } from "@reach/router";
 import * as QR from "avenger/lib/QueryResult";
 import { WithQueries } from "avenger/lib/react";

--- a/services/web/src/templates/EventTemplate.tsx
+++ b/services/web/src/templates/EventTemplate.tsx
@@ -2,11 +2,7 @@ import { ErrorBox } from "@econnessione/shared/components/Common/ErrorBox";
 import { Loader } from "@econnessione/shared/components/Common/Loader";
 import { EventPageContent } from "@econnessione/shared/components/EventPageContent";
 import { MainContent } from "@econnessione/shared/components/MainContent";
-import {
-  actorsList,
-  event,
-  groupsList,
-} from "@econnessione/shared/providers/DataProvider";
+import { Queries } from "@econnessione/shared/providers/DataProvider";
 import { RouteComponentProps } from "@reach/router";
 import * as QR from "avenger/lib/QueryResult";
 import { WithQueries } from "avenger/lib/react";
@@ -27,7 +23,11 @@ export default class EventTemplate extends React.PureComponent<
         () => <div>Missing event id</div>,
         (eventId) => (
           <WithQueries
-            queries={{ event: event, actors: actorsList, groups: groupsList }}
+            queries={{
+              event: Queries.Event.get,
+              actors: Queries.Actor.getList,
+              groups: Queries.Group.getList,
+            }}
             params={{
               event: { id: eventId },
               actors: {
@@ -51,7 +51,7 @@ export default class EventTemplate extends React.PureComponent<
               }) => (
                 <MainContent>
                   <EventPageContent
-                    event={event}
+                    event={event as any}
                     actors={actors}
                     groups={groups}
                   />

--- a/services/web/src/templates/GroupTemplate.tsx
+++ b/services/web/src/templates/GroupTemplate.tsx
@@ -5,11 +5,7 @@ import { GroupPageContent } from "@econnessione/shared/components/GroupPageConte
 import { MainContent } from "@econnessione/shared/components/MainContent";
 import SEO from "@econnessione/shared/components/SEO";
 import { EventSlider } from "@econnessione/shared/components/sliders/EventSlider";
-import {
-  group,
-  groupMembersList,
-  eventsList,
-} from "@econnessione/shared/providers/DataProvider";
+import { Queries } from "@econnessione/shared/providers/DataProvider";
 import { RouteComponentProps } from "@reach/router";
 import * as QR from "avenger/lib/QueryResult";
 import { WithQueries } from "avenger/lib/react";
@@ -31,9 +27,9 @@ export default class GroupTemplate extends React.PureComponent<
         (groupId) => (
           <WithQueries
             queries={{
-              group: group,
-              groupMembers: groupMembersList,
-              events: eventsList,
+              group: Queries.Group.get,
+              groupMembers: Queries.GroupMember.getList,
+              events: Queries.Event.getList,
             }}
             params={{
               group: { id: groupId },
@@ -61,25 +57,32 @@ export default class GroupTemplate extends React.PureComponent<
             render={QR.fold(
               Loader,
               ErrorBox,
-              ({ group, groupMembers, events }) => (
-                <MainContent>
-                  <SEO title={group.name} />
-                  <GroupPageContent
-                    {...group}
-                    groupMembers={groupMembers.data}
-                    events={events.data}
-                    funds={[]}
-                    projects={[]}
-                    onMemberClick={async (a) => {
-                      if (this.props.navigate !== undefined) {
-                        await this.props.navigate(`/actors/${a.id}`);
-                      }
-                    }}
-                  />
-                  <EventsMap filter={{ groups: O.some([group.id]) }} zoom={4} />
-                  <EventSlider filter={{ groups: O.some([group.id]) }} />
-                </MainContent>
-              )
+              ({ group, groupMembers, events }) => {
+                // eslint-disable-next-line
+                console.log({ group, groupMembers, events });
+                return (
+                  <MainContent>
+                    <SEO title={group.name} />
+                    <GroupPageContent
+                      {...group}
+                      groupMembers={groupMembers.data}
+                      events={events.data}
+                      funds={[]}
+                      projects={[]}
+                      onMemberClick={async (a) => {
+                        if (this.props.navigate !== undefined) {
+                          await this.props.navigate(`/actors/${a.id}`);
+                        }
+                      }}
+                    />
+                    <EventsMap
+                      filter={{ groups: O.some([group.id]) }}
+                      zoom={4}
+                    />
+                    <EventSlider filter={{ groups: O.some([group.id]) }} />
+                  </MainContent>
+                );
+              }
             )}
           />
         )

--- a/services/web/src/templates/ProjectTemplate.tsx
+++ b/services/web/src/templates/ProjectTemplate.tsx
@@ -4,7 +4,7 @@ import { MainContent } from "@econnessione/shared/components/MainContent";
 import { ProjectPageContent } from "@econnessione/shared/components/ProjectPageContent";
 import SEO from "@econnessione/shared/components/SEO";
 import { eventMetadataMapEmpty } from "@econnessione/shared/mock-data/events/events-metadata";
-import { project } from "@econnessione/shared/providers/DataProvider";
+import { Queries } from "@econnessione/shared/providers/DataProvider";
 import { RouteComponentProps } from "@reach/router";
 import * as QR from "avenger/lib/QueryResult";
 import { WithQueries } from "avenger/lib/react";
@@ -25,7 +25,7 @@ export default class ProjectTemplate extends React.PureComponent<
         () => <div>Missing project id</div>,
         (projectId) => (
           <WithQueries
-            queries={{ project: project }}
+            queries={{ project: Queries.Project.get }}
             params={{ project: { id: projectId } }}
             render={QR.fold(Loader, ErrorBox, ({ project }) => (
               <MainContent>


### PR DESCRIPTION
With endpoints defined with `ts-endpoint` we can derive the queries and commands used by the client to keep up with changes in the API.